### PR TITLE
Capture error in Set() and Clear()

### DIFF
--- a/gpio_linux.go
+++ b/gpio_linux.go
@@ -167,12 +167,12 @@ func (p *pin) setMode(mode Mode) error {
 
 // Set sets the pin level high.
 func (p *pin) Set() {
-	p.valueFile.Write(bytesSet)
+	_, p.err = p.valueFile.Write(bytesSet)
 }
 
 // Clear sets the pin level low.
 func (p *pin) Clear() {
-	p.valueFile.Write(bytesClear)
+	_, p.err = p.valueFile.Write(bytesClear)
 }
 
 // Get retrieves the current pin level.


### PR DESCRIPTION
Any error state from the `File.Write()` method was being ignored instead of being stored so that it could be queried by `Err()`.
