### PR TITLE
Couple of fixes for reading gpio pin value.

### DIFF
--- a/gpio_linux.go
+++ b/gpio_linux.go
@@ -179,7 +179,7 @@ func (p *pin) Clear() {
 func (p *pin) Get() bool {
 	bytes := make([]byte, 1)
 	_, p.err = p.valueFile.ReadAt(bytes, 0)
-	return bytes[0] != 0
+	return bytes[0] == bytesSet[0]
 }
 
 // Watch waits for the edge level to be triggered and then calls the callback

--- a/gpio_linux.go
+++ b/gpio_linux.go
@@ -178,7 +178,7 @@ func (p *pin) Clear() {
 // Get retrieves the current pin level.
 func (p *pin) Get() bool {
 	bytes := make([]byte, 1)
-	_, p.err = p.valueFile.Read(bytes)
+	_, p.err = p.valueFile.ReadAt(bytes, 0)
 	return bytes[0] != 0
 }
 


### PR DESCRIPTION
Without these, reading gpio values on the Raspberry Pi was erroring, or always returning true.