### PR TITLE
Support pull up/down resistor for RPi

### DIFF
--- a/rpi/rpi.go
+++ b/rpi/rpi.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 )
 
+type PullDirection uint8
+
 const (
 	// Physical addresses for various peripheral register sets
 
@@ -98,6 +100,10 @@ const (
 	GPIO24 = GPIO_P1_18
 	GPIO27 = GPIO_P1_13
 	GPIO17 = GPIO_P1_11
+
+	PullNone PullDirection = 0
+	PullDown PullDirection = 1
+	PullUp   PullDirection = 2
 )
 
 func initRPi() {


### PR DESCRIPTION
The sleep values are somewhat arbitrary (not sure what they should be in reality), but I think it's fine since the Python RPi library just does a NOP for 150 cycles. I tested this with some buttons on the GPIO.