### PR TITLE
Export Pin and a few of its attributes.

### DIFF
--- a/gpio.go
+++ b/gpio.go
@@ -23,8 +23,8 @@ const (
 // of an interrupt.
 type IRQEvent func()
 
-// Pin represents a GPIO pin.
-type Pin interface {
+// Pinner represents a GPIO pin.
+type Pinner interface {
 	Mode() Mode                      // gets the current pin mode
 	SetMode(Mode)                    // set the current pin mode
 	Set()                            // sets the pin state high

--- a/gpio_internal_test.go
+++ b/gpio_internal_test.go
@@ -1,4 +1,4 @@
 package gpio
 
 // test pin implements Pin
-var _ Pin = new(pin)
+var _ Pinner = new(Pin)


### PR DESCRIPTION
Fix #25. Export a Pin and a few of its attributes. I renamed the `Pin` interface to `Pinner`. The changes don't introduce incompatibilities. 